### PR TITLE
Update to new fetch-readablestream that properly supports abort()

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "balena-errors": "^3.0.0",
     "bluebird": "^3.3.4",
     "fetch-ponyfill": "^4.0.0",
-    "fetch-readablestream": "^0.1.0",
+    "fetch-readablestream": "^0.2.0",
     "lodash": "^4.6.1",
     "node-web-streams": "github:resin-io-modules/node-web-streams#emit-errors",
     "progress-stream": "^2.0.0",


### PR DESCRIPTION
This brings in the changes from https://github.com/jonnyreeves/fetch-readablestream/pull/7. This should meant that abort is now fully supported in modern browsers, so they will totally close the backing request streams that are opened when viewing logs (rather than just stopping listening to them).

Change-type: patch