### PR TITLE
Switches balena-auth peerDependency package to match that in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "rindle": "^1.3.1"
   },
   "peerDependencies": {
-    "balena-auth": "^2.0.0"
+    "balena-auth": "^3.0.0"
   }
 }


### PR DESCRIPTION
`balena-auth` 2 does not exist, and it's set to 3 in devDependencies