### PR TITLE
Fix invalid balena-auth peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "rindle": "^1.3.1"
   },
   "peerDependencies": {
-    "balena-auth": "^2.0.0"
+    "balena-auth": "^3.0.0"
   }
 }


### PR DESCRIPTION
This was probably missed during the rename PR.
It seems that we updated the devDependency to v3
and missed to also update the version for the
peerDependency.
PS: balena-auth starts with v3.

Resolves: #133
See: https://github.com/balena-io-modules/balena-request/pull/129/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R47
See: https://github.com/balena-io/balena-sdk/issues/663
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>