### PR TITLE
Add the build directory to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pids
 node_modules
 
 .vscode
+
+build/


### PR DESCRIPTION
It seems that this was forgotten while doing https://github.com/balena-io-modules/balena-request/pull/136/commits/793f2f4104a06d8a2fe019a537350b1f6cf413e3

Change-type: patch