### PR TITLE
Fix passing baseUrl to refreshToken if the request uses an absolute url

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -54,18 +54,19 @@ export function getRequest({
 		if (options == null) {
 			options = {};
 		}
-		options = Object.assign(
-			{
-				method: 'GET',
-				json: true,
-				strictSSL: true,
-				headers: {},
-				sendToken: true,
-				refreshToken: true,
-				retries,
-			},
-			options,
-		);
+
+		const { baseUrl } = options;
+
+		options = {
+			method: 'GET',
+			json: true,
+			strictSSL: true,
+			headers: {},
+			sendToken: true,
+			refreshToken: true,
+			retries,
+			...options,
+		};
 
 		if (options.uri) {
 			options.url = options.uri;
@@ -80,7 +81,7 @@ export function getRequest({
 		if (auth != null && options.sendToken && options.refreshToken) {
 			const shouldRefreshKey = await utils.shouldRefreshKey(auth);
 			if (shouldRefreshKey) {
-				await exports.refreshToken(options);
+				await exports.refreshToken({ baseUrl });
 			}
 		}
 		const authorizationHeader = options.sendToken


### PR DESCRIPTION
Change-type: patch