### PR TITLE
Add tokenRefreshBaseUrl option to limit the refresh token targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It accepts the following params:
 | --- | --- | --- |
 | options | <code>Object</code> | options |
 | options.auth | <code>Object</code> | An instantiated [balena-auth](https://github.com/balena-io-modules/balena-auth) instance |
+| [options.tokenRefreshBaseUrl] | <code>string</code> | When provided, all refresh token requests will use it as their base url. |
 | options.debug | <code>boolean</code> | when set to `true` will log the request details in case of error. |
 | options.isBrowser | <code>boolean</code> | set to `true` if the runtime is the browser. |
 | options.interceptors | <code>Array&lt;Interceptor&gt;</code> | An initial array of interceptors |

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -38,6 +38,7 @@ It accepts the following params:
 | --- | --- | --- |
 | options | <code>Object</code> | options |
 | options.auth | <code>Object</code> | An instantiated [balena-auth](https://github.com/balena-io-modules/balena-auth) instance |
+| [options.tokenRefreshBaseUrl] | <code>string</code> | When provided, all refresh token requests will use it as their base url. |
 | options.debug | <code>boolean</code> | when set to `true` will log the request details in case of error. |
 | options.isBrowser | <code>boolean</code> | set to `true` if the runtime is the browser. |
 | options.interceptors | <code>Array&lt;Interceptor&gt;</code> | An initial array of interceptors |

--- a/lib/request.js
+++ b/lib/request.js
@@ -25,6 +25,7 @@ import * as utils from './utils';
 /**
  * @param {object} options
  * @param {import('balena-auth').default} options.auth
+ * @param {string} [options.tokenRefreshBaseUrl]
  * @param {boolean} options.debug
  * @param {number} options.retries
  * @param {boolean} options.isBrowser
@@ -32,6 +33,7 @@ import * as utils from './utils';
  */
 export function getRequest({
 	auth,
+	tokenRefreshBaseUrl,
 	debug = false,
 	retries = 0,
 	isBrowser = false,
@@ -81,7 +83,7 @@ export function getRequest({
 		if (auth != null && options.sendToken && options.refreshToken) {
 			const shouldRefreshKey = await utils.shouldRefreshKey(auth);
 			if (shouldRefreshKey) {
-				await exports.refreshToken({ baseUrl });
+				await exports.refreshToken({ baseUrl: tokenRefreshBaseUrl ?? baseUrl });
 			}
 		}
 		const authorizationHeader = options.sendToken


### PR DESCRIPTION
This way token refresh attempts can be configured to only be sent against a specific API baseUrl.

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/XVvB7BhMFMXAXsQNwACFg5seFyQ
See: https://github.com/balena-io/balena-ui/issues/3942
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>