### PR TITLE
Stop refreshing the token on absolute urls

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -72,16 +72,24 @@ export function getRequest({
 			options.url = options.uri;
 			delete options.uri;
 		}
-		if (urlLib.parse(options.url).protocol != null) {
+		const isAbsoluteUrl = urlLib.parse(options.url).protocol != null;
+		if (isAbsoluteUrl) {
 			delete options.baseUrl;
 		}
 
 		// Only refresh if we have balena-auth, we're going to use it to send a
 		// token, and we haven't opted out of refresh
-		if (auth != null && options.sendToken && options.refreshToken) {
-			const shouldRefreshKey = await utils.shouldRefreshKey(auth);
-			if (shouldRefreshKey) {
+		if (
+			auth != null &&
+			options.sendToken &&
+			options.refreshToken &&
+			(await utils.shouldRefreshKey(auth))
+		) {
+			if (!isAbsoluteUrl) {
 				await exports.refreshToken({ baseUrl });
+			}
+			if (await auth.isExpired()) {
+				throw new errors.BalenaExpiredToken(await auth.getKey());
 			}
 		}
 		const authorizationHeader = options.sendToken

--- a/tests/hooks.spec.coffee
+++ b/tests/hooks.spec.coffee
@@ -111,23 +111,47 @@ describe 'An interceptor', ->
 			afterEach ->
 				@utilsShouldUpdateToken.restore()
 
-			it 'should call requestError if the token is expired', ->
-				request.interceptors[0] =
-					requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
+			describe 'when using a baseUrl', ->
 
-				promise = request.send
-					url: mockServer.url
+				it 'should call requestError if the token is expired', ->
+					request.interceptors[0] =
+						requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
 
-				m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
+					promise = request.send
+						baseUrl: mockServer.url
+						url: '/'
 
-			it 'should call requestError if the token is expired for stream()', ->
-				request.interceptors[0] =
-					requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
+					m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
 
-				promise = request.stream
-					url: mockServer.url
+				it 'should call requestError if the token is expired for stream()', ->
+					request.interceptors[0] =
+						requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
 
-				m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
+					promise = request.stream
+						baseUrl: mockServer.url
+						url: '/'
+
+					m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
+
+			describe 'when using an absolute url', ->
+
+				it 'should call requestError if the token is expired', ->
+					request.interceptors[0] =
+						requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
+
+					promise = request.send
+						url: mockServer.url
+
+					m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
+
+				it 'should call requestError if the token is expired for stream()', ->
+					request.interceptors[0] =
+						requestError: m.sinon.mock().throws(new Error('intercepted auth failure'))
+
+					promise = request.stream
+						url: mockServer.url
+
+					m.chai.expect(promise).to.be.rejectedWith('intercepted auth failure')
 
 	describe 'with a response hook', ->
 


### PR DESCRIPTION
Essentially reverting v11.0.1 but rejecting with a
better error than before.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/XVvB7BhMFMXAXsQNwACFg5seFyQ
See: https://github.com/balena-io/balena-ui/issues/3942
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>