### PR TITLE
Update fetch-ponyfill to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@balena/node-web-streams": "^0.2.3",
     "balena-errors": "^4.7.1",
-    "fetch-ponyfill": "^6.1.1",
+    "fetch-ponyfill": "^7.1.0",
     "fetch-readablestream": "^0.2.0",
     "progress-stream": "^2.0.0",
     "qs": "^6.9.4",


### PR DESCRIPTION
The only breaking change is dropping support
for node v8 but we have already done that in v11.

Change-type: minor
See: https://github.com/qubyte/fetch-ponyfill/blob/main/HISTORY.md#700
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>