### PR TITLE
Switch to the versioned token refresh endpoint

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -386,7 +386,7 @@ export function getRequest({
 		let response;
 		try {
 			response = await exports.send({
-				url: '/whoami',
+				url: '/user/v1/refresh-token',
 				baseUrl,
 				refreshToken: false,
 			});

--- a/tests/token.spec.coffee
+++ b/tests/token.spec.coffee
@@ -88,10 +88,10 @@ describe 'Request (token):', ->
 					@utilsShouldUpdateToken.restore()
 					@authIsExpired.restore()
 
-				describe 'given a working /whoami endpoint', ->
+				describe 'given a working /user/v1/refresh-token endpoint', ->
 
 					beforeEach ->
-						mockServer.get('/whoami').thenReply(200, janeDoeFixture.token)
+						mockServer.get('/user/v1/refresh-token').thenReply(200, janeDoeFixture.token)
 
 					describe 'given no base url', ->
 
@@ -133,10 +133,10 @@ describe 'Request (token):', ->
 							authorizationHeader = response.request.headers.Authorization
 							m.chai.expect(authorizationHeader).to.equal("Bearer #{janeDoeFixture.token}")
 
-				describe 'given /whoami returns 401', ->
+				describe 'given /user/v1/refresh-token returns 401', ->
 
 					beforeEach ->
-						mockServer.get('/whoami').thenReply(401, 'Unauthorized')
+						mockServer.get('/user/v1/refresh-token').thenReply(401, 'Unauthorized')
 
 					describe 'given an absolute url', ->
 
@@ -174,10 +174,10 @@ describe 'Request (token):', ->
 							auth.hasKey().then (hasKey) ->
 								m.chai.expect(hasKey).to.be.false
 
-				describe 'given /whoami returns a non 401 status code', ->
+				describe 'given /user/v1/refresh-token returns a non 401 status code', ->
 
 					beforeEach ->
-						mockServer.get('/whoami').thenReply(500)
+						mockServer.get('/user/v1/refresh-token').thenReply(500)
 
 					it 'should be rejected with a request error', ->
 						promise = request.send
@@ -233,11 +233,11 @@ describe 'Request (token):', ->
 
 	describe '.refreshToken()', ->
 
-		describe 'given a working /whoami endpoint', ->
+		describe 'given a working /user/v1/refresh-token endpoint', ->
 
 			beforeEach ->
 				auth.setKey(johnDoeFixture.token)
-				mockServer.get('/whoami').thenReply(200, janeDoeFixture.token)
+				mockServer.get('/user/v1/refresh-token').thenReply(200, janeDoeFixture.token)
 
 			it 'should refresh the token', ->
 				auth.getKey().then (savedToken) ->


### PR DESCRIPTION
Minor since that endpoint was available on balenaCloud way before our latest major release (v11) and none of the two are at the moment available in open-balena.

Change-type: minor
See: https://github.com/balena-io/balena-api/blob/509ab434d9b52a9649955df2a212c87bf4e82d0e/src/routes/index.ts#L35-L40
See: https://github.com/balena-io/balena-api/blob/509ab434d9b52a9649955df2a212c87bf4e82d0e/src/routes/index.ts#L225-L230
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>
