### PR TITLE
Allow more lenient gzip decompression

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -126,8 +126,18 @@ export function estimate(requestAsync, isBrowser) {
 		);
 
 		if (!isBrowser && utils.isResponseCompressed(response)) {
-			const { createGunzip } = require('zlib');
-			const gunzip = createGunzip();
+			const zlib = require('zlib');
+
+			// Be more lenient with decoding compressed responses, since (very rarely)
+			// servers send slightly invalid gzip responses that are still accepted
+			// by common browsers.
+			// Always using Z_SYNC_FLUSH is what cURL does.
+			var zlibOptions = {
+				flush: zlib.constants.Z_SYNC_FLUSH,
+				finishFlush: zlib.constants.Z_SYNC_FLUSH,
+			};
+
+			const gunzip = zlib.createGunzip(zlibOptions);
 
 			// Uncompress after or before piping through progress
 			// depending on the response length available to us

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,10 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const {
-	fetch: normalFetch,
-	Headers: HeadersPonyfill,
-} = require('fetch-ponyfill')({ Promise });
+const { fetch: normalFetch, Headers: HeadersPonyfill } =
+	require('fetch-ponyfill')({ Promise });
 import * as urlLib from 'url';
 import * as qs from 'qs';
 import * as errors from 'balena-errors';


### PR DESCRIPTION
Be more lenient with decoding compressed responses, since (very rarely)
servers send slightly invalid gzip responses that are still accepted
by common browsers.

Always using Z_SYNC_FLUSH is what cURL does.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Related upstream PR: https://github.com/request/request/pull/2492