### PR TITLE
increase node fetch buffer size

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -118,7 +118,7 @@ export function estimate(requestAsync, isBrowser) {
 			responseStream = webStreams.toNodeReadable(response.body);
 			reader = responseStream._reader;
 		} else {
-			responseStream = response.body;
+			responseStream = response.clone().body;
 		}
 
 		const progressStream = getProgressStream(total, (state) =>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -271,6 +271,7 @@ const processRequestOptions = function (options) {
 	opts.body = body;
 
 	if (!IS_BROWSER) {
+		opts.highWaterMark = 1024 * 1024; // about 1MB
 		if (!headers['Accept-Encoding']) {
 			headers['Accept-Encoding'] = 'compress, gzip';
 		}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "zlib-browserify": "0.0.3"
   },
   "dependencies": {
-    "@balena/node-web-streams": "^0.2.3",
+    "@balena/node-web-streams": "^0.2.4",
     "balena-errors": "^4.7.1",
     "fetch-ponyfill": "^7.1.0",
     "fetch-readablestream": "^0.2.0",


### PR DESCRIPTION
Hopefully fixes https://github.com/balena-io/balena-cli/issues/2152

Request hangs due to low buffer size, per https://github.com/node-fetch/node-fetch#custom-highwatermark

Change-type: patch