### PR TITLE
Allow overriding the default zlib flush setting

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -137,7 +137,18 @@ export function estimate(requestAsync, isBrowser) {
 				finishFlush: zlib.constants.Z_SYNC_FLUSH,
 			};
 
+			// Allow overriding this behaviour by setting the ZLIB_FLUSH env var
+			// to one of the allowed zlib flush values (process.env.ZLIB_FLUSH="Z_NO_FLUSH").
+			// https://github.com/nodejs/node/blob/master/doc/api/zlib.md#zlib-constants
+			if (process.env.ZLIB_FLUSH && process.env.ZLIB_FLUSH in zlib.constants) {
+				zlibOptions = {
+					flush: zlib.constants[process.env.ZLIB_FLUSH],
+					finishFlush: zlib.constants[process.env.ZLIB_FLUSH],
+				};
+			}
+
 			const gunzip = zlib.createGunzip(zlibOptions);
+			gunzip.on('error', (e) => output.emit('error', e));
 
 			// Uncompress after or before piping through progress
 			// depending on the response length available to us


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>