### PR TITLE
Use response error as response message if there is one

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -118,6 +118,15 @@ export function getErrorMessageFromResponse(response: BalenaRequestResponse) {
 		return errorText;
 	}
 
+	if (response.body != null && typeof response.body === 'object') {
+		const bodyMessageProp = ['message', 'error'].find(
+			(prop) => typeof response.body[prop] === 'string',
+		);
+		if (bodyMessageProp != null) {
+			response.body.message = response.body[bodyMessageProp];
+		}
+	}
+
 	return response.body;
 }
 


### PR DESCRIPTION
Use response error as response message if there is one

Connects-to: https://github.com/balena-io/balena-ui/pull/5427
Change-type: patch
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>