### PR TITLE
Increase TOKEN_REFRESH_INTERVAL from 1 hours to 1 day

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,7 +37,7 @@ const IS_BROWSER = typeof window !== 'undefined' && window !== null;
  * @module utils
  */
 
-export const TOKEN_REFRESH_INTERVAL = 1 * 60 * 60 * 1000; // 1 hour in milliseconds
+export const TOKEN_REFRESH_INTERVAL = 24 * 60 * 60 * 1000; // 1 day in milliseconds
 
 /**
  * @summary Determine if the token should be updated


### PR DESCRIPTION
Change-type: minor

Current behaviour of trying to refresh the token after it has lived for 1 hour is too aggressive, and for non refreshable tokens with smaller TTL it might generatae undesired behaviour such as trying to renew the token (and failing) on all requests, so we decided to increase this interval and the client can renew it themselves more frequently if necessary.