### PR TITLE
Abstract the timeout implementation

### DIFF
--- a/lib/progress.ts
+++ b/lib/progress.ts
@@ -137,7 +137,7 @@ export function estimate(requestAsync: ReturnType<typeof getRequestAsync>) {
 		output.response = response;
 
 		const responseLength = utils.getResponseLength(response);
-		const total = responseLength.uncompressed || responseLength.compressed;
+		const total = responseLength.uncompressed ?? responseLength.compressed;
 
 		let responseStream: any;
 		if (response.body.getReader) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -224,7 +224,7 @@ export function debugRequest(
 	options: BalenaRequestOptions,
 	response: BalenaRequestResponse,
 ) {
-	return console.error({
+	console.error({
 		statusCode: response.statusCode,
 		duration: response.duration,
 		...options,
@@ -284,7 +284,7 @@ const processRequestOptions = function (options: BalenaRequestOptions) {
 	}
 	if (options.qs) {
 		const params = qs.stringify(options.qs);
-		url += (url.indexOf('?') >= 0 ? '&' : '?') + params;
+		url += (url.includes('?') ? '&' : '?') + params;
 	}
 
 	let { body, headers } = options;
@@ -415,7 +415,9 @@ async function requestAsync(
 		// As a result when fetch-readablestream uses the native fetch on Edge, the headers sent
 		// to the server only contain a `map` property and not the actual headers that we want.
 		const nativeHeaders = new Headers();
-		opts.headers.forEach((value, name) => nativeHeaders.append(name, value));
+		opts.headers.forEach((value, name) => {
+			nativeHeaders.append(name, value);
+		});
 		opts.headers = nativeHeaders;
 	}
 
@@ -522,7 +524,7 @@ function handleAbortIfNotSupported(
 		if (signal.aborted) {
 			return emulateAbort();
 		} else {
-			return signal.addEventListener('abort', () => emulateAbort(), {
+			signal.addEventListener('abort', () => emulateAbort(), {
 				once: true,
 			});
 		}

--- a/tests/request.spec.ts
+++ b/tests/request.spec.ts
@@ -373,18 +373,16 @@ describe('Request:', function () {
 							.thenJson(200, { matched: true }),
 					);
 
-					it('should eventually return the body', function () {
-						const promise = request
-							.send({
-								method: upperMethod,
-								baseUrl: mockServer.url,
-								url: '/',
-								body: {
-									foo: 'bar',
-								},
-							})
-							.then((v) => v.body);
-						return expect(promise).to.eventually.become({ matched: true });
+					it('should eventually return the body', async function () {
+						const { body } = await request.send({
+							method: upperMethod,
+							baseUrl: mockServer.url,
+							url: '/',
+							body: {
+								foo: 'bar',
+							},
+						});
+						expect(body).to.deep.equal({ matched: true });
 					});
 				}),
 			);
@@ -392,11 +390,9 @@ describe('Request:', function () {
 
 		describe('given a body with a Blob data', function () {
 			beforeEach(async () => {
-				await mockServer
-					.forPost('/multipart-endpoint')
-					.thenCallback(async (req) => {
-						return { statusCode: 200, body: req.headers['content-type'] };
-					});
+				await mockServer.forPost('/multipart-endpoint').thenCallback((req) => {
+					return { statusCode: 200, body: req.headers['content-type'] };
+				});
 			});
 			it('should send the request as multipart/form-data with boundary', async function () {
 				const fileName = 'testfile.txt';

--- a/tests/response-format.spec.ts
+++ b/tests/response-format.spec.ts
@@ -76,8 +76,10 @@ describe('responseFormat:', function () {
 					// use the FileReader to read the blob content as a string
 					return new Promise(function (resolve) {
 						const reader = new FileReader();
-						reader.addEventListener('loadend', () => resolve(reader.result));
-						return reader.readAsText(body);
+						reader.addEventListener('loadend', () => {
+							resolve(reader.result);
+						});
+						reader.readAsText(body);
 					});
 				});
 			return expect(promise).to.eventually.satisfy(function (body: any) {

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -236,7 +236,7 @@ describe('Utils:', function () {
 				headers: new Headers({
 					'content-encoding': 'gzip',
 				}),
-			} as BalenaRequestResponse<any>;
+			} as BalenaRequestResponse;
 
 			return expect(utils.isResponseCompressed(response)).to.be.true;
 		});
@@ -244,7 +244,7 @@ describe('Utils:', function () {
 		it('should return false if Content-Encoding is not set', function () {
 			const response = {
 				headers: new Headers({}),
-			} as BalenaRequestResponse<any>;
+			} as BalenaRequestResponse;
 
 			return expect(utils.isResponseCompressed(response)).to.be.false;
 		});


### PR DESCRIPTION
Allows us to cast the result of the fetch a bit earlier and re-uses the timeout helper that we have in the UI.

Change-type: patch
See: https://balena.fibery.io/Work/Project/Use-native-fetch-for-non-streaming-requests-1568